### PR TITLE
Configurable host and origin header

### DIFF
--- a/dggchat.go
+++ b/dggchat.go
@@ -3,6 +3,8 @@ package dggchat
 
 import (
 	"errors"
+	"net/url"
+	"os"
 
 	"github.com/gorilla/websocket"
 )
@@ -13,15 +15,22 @@ var ErrTooManyArgs = errors.New("function called with unexcepted amount of argum
 // New creates a new destinygg session. Accepts either 0 or 1 arguments.
 // If no login key is provided, a read-only session is returned
 func New(args ...string) (*Session, error) {
+
 	if len(args) > 1 {
 		return nil, ErrTooManyArgs
 	}
-
 	s := &Session{
 		attempToReconnect: true,
 		state:             newState(),
-		wsURL:             wsURL,
 		dialer:            websocket.DefaultDialer,
+	}
+	customHost, customHostExist := os.LookupEnv("CUSTOM_WSHOST")
+	if customHostExist {
+		s.wsURL = url.URL{Scheme: "wss", Host: customHost, Path: "/wss"}
+	}
+	customOriginHeader, customOriginHeaderExist := os.LookupEnv("CUSTOM_ORIGINHEADER")
+	if customOriginHeaderExist {
+		s.originHeader = customOriginHeader
 	}
 	if len(args) == 1 {
 		s.loginKey = args[0]

--- a/dggchat.go
+++ b/dggchat.go
@@ -27,6 +27,8 @@ func New(args ...string) (*Session, error) {
 	customHost, customHostExist := os.LookupEnv("CUSTOM_WSHOST")
 	if customHostExist {
 		s.wsURL = url.URL{Scheme: "wss", Host: customHost, Path: "/wss"}
+	} else {
+		s.wsURL = wsURL
 	}
 	customOriginHeader, customOriginHeaderExist := os.LookupEnv("CUSTOM_ORIGINHEADER")
 	if customOriginHeaderExist {

--- a/dggchat.go
+++ b/dggchat.go
@@ -26,7 +26,7 @@ func New(args ...string) (*Session, error) {
 	}
 	customHost, customHostExist := os.LookupEnv("CUSTOM_WSHOST")
 	if customHostExist {
-		s.wsURL = url.URL{Scheme: "wss", Host: customHost, Path: "/wss"}
+		s.wsURL = url.URL{Scheme: "wss", Host: customHost, Path: "/ws"}
 	} else {
 		s.wsURL = wsURL
 	}

--- a/session.go
+++ b/session.go
@@ -19,13 +19,14 @@ type Session struct {
 	// If true, attempt to reconnect on error
 	attempToReconnect bool
 
-	readOnly bool
-	loginKey string
-	wsURL    url.URL
-	ws       *websocket.Conn
-	handlers handlers
-	state    *state
-	dialer   *websocket.Dialer
+	readOnly     bool
+	loginKey     string
+	originHeader string
+	wsURL        url.URL
+	ws           *websocket.Conn
+	handlers     handlers
+	state        *state
+	dialer       *websocket.Dialer
 }
 
 type messageOut struct {
@@ -102,6 +103,12 @@ func (s *Session) open() error {
 	}
 
 	header := http.Header{}
+	if strings.TrimSpace(s.originHeader) != "" {
+		_, err := url.ParseRequestURI(s.originHeader)
+		if err != nil {
+			header.Add("Origin", s.originHeader)
+		}
+	}
 	if !s.readOnly {
 		header.Add("Cookie", fmt.Sprintf("authtoken=%s", s.loginKey))
 	}


### PR DESCRIPTION
Hi
I am submitting another pull request which shouldn't break existing configurations and bots. The config is done via environment variables and is non-destructive. If the variables are not set the functionality of the library will be the same as w/o the changes present in this PR.

This will prepare the library for the upcoming dgg websocket url change.

With the following env vars set the library will sucessfully connect to the new websocket url:
**CUSTOM_WSHOST=chat.destiny.gg**
**CUSTOM_ORIGINHEADER=https://www.destiny.gg**

My proposed changes have been tested and are working with my bot tng69.