### PR TITLE
Add support for subscriptions and donation messages

### DIFF
--- a/eventHandlers.go
+++ b/eventHandlers.go
@@ -24,6 +24,7 @@ func (s *Session) AddMessageHandler(fn func(Message, *Session)) {
 	s.handlers.msgHandler = fn
 }
 
+// AddPinHandler adds a function that will be called every time a pin message is received
 func (s *Session) AddPinHandler(fn func(Pin, *Session)) {
 	s.handlers.pinHandler = fn
 }

--- a/eventHandlers.go
+++ b/eventHandlers.go
@@ -1,20 +1,22 @@
 package dggchat
 
 type handlers struct {
-	msgHandler       func(Message, *Session)
-	pinHandler       func(Pin, *Session)
-	namesHandler     func(Names, *Session)
-	muteHandler      func(Mute, *Session)
-	unmuteHandler    func(Mute, *Session)
-	banHandler       func(Ban, *Session)
-	unbanHandler     func(Ban, *Session)
-	errHandler       func(string, *Session)
-	joinHandler      func(RoomAction, *Session)
-	quitHandler      func(RoomAction, *Session)
-	pmHandler        func(PrivateMessage, *Session)
-	broadcastHandler func(Broadcast, *Session)
-	pingHandler      func(Ping, *Session)
-	subOnlyHandler   func(SubOnly, *Session)
+	msgHandler          func(Message, *Session)
+	pinHandler          func(Pin, *Session)
+	namesHandler        func(Names, *Session)
+	muteHandler         func(Mute, *Session)
+	unmuteHandler       func(Mute, *Session)
+	banHandler          func(Ban, *Session)
+	unbanHandler        func(Ban, *Session)
+	errHandler          func(string, *Session)
+	joinHandler         func(RoomAction, *Session)
+	quitHandler         func(RoomAction, *Session)
+	pmHandler           func(PrivateMessage, *Session)
+	broadcastHandler    func(Broadcast, *Session)
+	subscriptionHandler func(Subscription, *Session)
+	donationHandler     func(Donation, *Session)
+	pingHandler         func(Ping, *Session)
+	subOnlyHandler      func(SubOnly, *Session)
 
 	socketErrorHandler func(error, *Session)
 }
@@ -77,6 +79,16 @@ func (s *Session) AddPMHandler(fn func(PrivateMessage, *Session)) {
 // AddBroadcastHandler adds a function that will be called every time a broadcast is sent to the chat
 func (s *Session) AddBroadcastHandler(fn func(Broadcast, *Session)) {
 	s.handlers.broadcastHandler = fn
+}
+
+// AddSubscriptionHandler adds a function that will be called every time a (regular, gifted, or a mass gift) subscription message is received
+func (s *Session) AddSubscriptionHandler(fn func(Subscription, *Session)) {
+	s.handlers.subscriptionHandler = fn
+}
+
+// AddDonationHandler adds a function that will be called every time a donation message is received
+func (s *Session) AddDonationHandler(fn func(Donation, *Session)) {
+	s.handlers.donationHandler = fn
 }
 
 // AddPingHandler adds a function that will be called when a server responds with a pong

--- a/messageStructs.go
+++ b/messageStructs.go
@@ -145,6 +145,54 @@ type (
 		UUID string `json:"uuid"`
 	}
 
+	// SubTier represents a dgg subscription tier
+	SubTier struct {
+		Tier  int64
+		Label string
+	}
+
+	// Subscription represents a dgg subscription message
+	Subscription struct {
+		Sender    User
+		Recipient User
+		Timestamp time.Time
+		Message   string
+		Tier      SubTier
+		Quantity  int64
+		UUID      string
+	}
+
+	subscription struct {
+		Data      string `json:"data"`
+		Timestamp int64  `json:"timestamp"`
+		Nick      string `json:"nick"`
+		Tier      int64  `json:"tier"`
+		TierLabel string `json:"tierLabel"`
+		Giftee    string `json:"giftee"`
+		Quantity  int64  `json:"quantity"`
+		User      User   `json:"user"`
+		Recipient User   `json:"recipient"`
+		UUID      string `json:"uuid"`
+	}
+
+	// Donation represents a dgg donation message
+	Donation struct {
+		Sender    User
+		Timestamp time.Time
+		Message   string
+		Amount    int64
+		UUID      string
+	}
+
+	donation struct {
+		Data      string `json:"data"`
+		Timestamp int64  `json:"timestamp"`
+		Nick      string `json:"nick"`
+		Amount    int64  `json:"amount"`
+		User      User   `json:"user"`
+		UUID      string `json:"uuid"`
+	}
+
 	// Ping represents a pong response from the server
 	Ping struct {
 		Timestamp int64 `json:"timestamp"`
@@ -181,4 +229,14 @@ func (u *User) HasFeature(s string) bool {
 // IsAction returns true if the message was an action (/me)
 func (m *Message) IsAction() bool {
 	return strings.HasPrefix(m.Message, "/me ")
+}
+
+// IsGift returns true if the subscription was a gift
+func (s *Subscription) IsGift() bool {
+	return s.Sender.Nick != s.Recipient.Nick
+}
+
+// IsMassGift returns true if the subscription was a mass gift
+func (s *Subscription) IsMassGift() bool {
+	return s.Quantity > 0
 }

--- a/messageStructs.go
+++ b/messageStructs.go
@@ -137,6 +137,12 @@ type (
 		Sender    User
 		Timestamp time.Time
 		Message   string
+		UUID      string
+	}
+
+	broadcast struct {
+		message
+		UUID string `json:"uuid"`
 	}
 
 	// Ping represents a pong response from the server

--- a/messageStructs.go
+++ b/messageStructs.go
@@ -136,13 +136,8 @@ type (
 	Broadcast struct {
 		Sender    User
 		Timestamp time.Time
-		Message   string
-		UUID      string
-	}
-
-	broadcast struct {
-		message
-		UUID string `json:"uuid"`
+		Message   string `json:"data"`
+		UUID      string `json:"uuid"`
 	}
 
 	// SubTier represents a dgg subscription tier

--- a/parsers.go
+++ b/parsers.go
@@ -155,25 +155,13 @@ func parsePrivateMessage(s string, sess *Session) (PrivateMessage, error) {
 }
 
 func parseBroadcast(s string) (Broadcast, error) {
-	var m broadcast
+	var m Broadcast
 
-	err := json.Unmarshal([]byte(s), &m)
-	if err != nil {
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
 		return Broadcast{}, err
 	}
 
-	user := User{
-		Nick:     m.Nick,
-		Features: m.Features,
-	}
-
-	broadcast := Broadcast{
-		Sender:    user,
-		Message:   m.Data,
-		Timestamp: unixToTime(m.Timestamp),
-	}
-
-	return broadcast, nil
+	return m, nil
 }
 
 func parseSubscription(s string) (Subscription, error) {

--- a/parsers.go
+++ b/parsers.go
@@ -155,7 +155,7 @@ func parsePrivateMessage(s string, sess *Session) (PrivateMessage, error) {
 }
 
 func parseBroadcast(s string) (Broadcast, error) {
-	var m message
+	var m broadcast
 
 	err := json.Unmarshal([]byte(s), &m)
 	if err != nil {

--- a/parsers.go
+++ b/parsers.go
@@ -176,6 +176,52 @@ func parseBroadcast(s string) (Broadcast, error) {
 	return broadcast, nil
 }
 
+func parseSubscription(s string) (Subscription, error) {
+	var sub subscription
+	if err := json.Unmarshal([]byte(s), &sub); err != nil {
+		return Subscription{}, err
+	}
+
+	recipient := sub.Recipient
+	if recipient.Nick == "" {
+		recipient = sub.User
+	}
+
+	tier := SubTier{
+		Tier:  sub.Tier,
+		Label: sub.TierLabel,
+	}
+
+	subscription := Subscription{
+		Sender:    sub.User,
+		Recipient: recipient,
+		Timestamp: unixToTime(sub.Timestamp),
+		Message:   sub.Data,
+		Tier:      tier,
+		Quantity:  sub.Quantity,
+		UUID:      sub.UUID,
+	}
+
+	return subscription, nil
+}
+
+func parseDonation(s string) (Donation, error) {
+	var dono donation
+	if err := json.Unmarshal([]byte(s), &dono); err != nil {
+		return Donation{}, err
+	}
+
+	donation := Donation{
+		Sender:    dono.User,
+		Timestamp: unixToTime(dono.Timestamp),
+		Message:   dono.Data,
+		Amount:    dono.Amount,
+		UUID:      dono.UUID,
+	}
+
+	return donation, nil
+}
+
 func parseSubOnly(s string) (SubOnly, error) {
 	var so subOnly
 

--- a/session.go
+++ b/session.go
@@ -204,6 +204,20 @@ func (s *Session) listen() {
 			}
 			s.handlers.pinHandler(pin, s)
 
+		case "SUBSCRIPTION", "GIFTSUB", "MASSGIFT":
+			sub, err := parseSubscription(mContent)
+			if s.handlers.subscriptionHandler == nil || err != nil {
+				continue
+			}
+			s.handlers.subscriptionHandler(sub, s)
+
+		case "DONATION":
+			dono, err := parseDonation(mContent)
+			if s.handlers.donationHandler == nil || err != nil {
+				continue
+			}
+			s.handlers.donationHandler(dono, s)
+
 		case "MUTE":
 			mute, err := parseMute(mContent, s)
 			if s.handlers.muteHandler == nil || err != nil {


### PR DESCRIPTION
- Add support for ```SUBSCRIPTION```, ```GIFTSUB```, ```MASSGIFT``` and ```DONATION``` websocket messages that got added to dgg a few months ago.
- Add the UUID field to the ```BROADCAST``` message.

I'm not 100% sure if merging every subscription type into one struct is the right approach, though it seems reasonably clean to me. You can determine the type via ```IsGift()``` and ```IsMassGift()```:

```go
func onSubscription(m dggchat.Subscription, s *dggchat.Session) {
	switch {
	case m.IsGift():
		log.Printf("New gift: %+v\n", m)
	case m.IsMassGift():
		log.Printf("New mass gift: %+v\n", m)
	default:
		log.Printf("New subscription: %+v\n", m)
	}
}
```

If you'd like me to split it up into separate handlers and structs, let me know! :smiley: