### PR TITLE
Use the full timestamp provided by chat

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/MemeLabs/dggchat
 
-go 1.15
+go 1.21.3
 
 require github.com/gorilla/websocket v1.4.2

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/MemeLabs/dggchat
 
-go 1.21.3
+go 1.21
 
 require github.com/gorilla/websocket v1.4.2

--- a/parsers.go
+++ b/parsers.go
@@ -216,7 +216,7 @@ func parsePing(s string) (Ping, error) {
 }
 
 func unixToTime(stamp int64) time.Time {
-	return time.Unix(stamp/1000, 0)
+	return time.Unix(stamp/1e3, (stamp%1e3)*1e6)
 }
 
 func timeToUnix(t time.Time) int64 {

--- a/parsers.go
+++ b/parsers.go
@@ -216,7 +216,7 @@ func parsePing(s string) (Ping, error) {
 }
 
 func unixToTime(stamp int64) time.Time {
-	return time.Unix(stamp/1e3, (stamp%1e3)*1e6)
+	return time.UnixMilli(stamp)
 }
 
 func timeToUnix(t time.Time) int64 {


### PR DESCRIPTION
There's a stock ```time.UnixMilli()``` function that literally does the same thing, but it was added go 1.17, while go.mod here specifies 1.15. I can bump the version up instead if you'd like me to FeelsOkayMan