### PR TITLE
Revert "fix: subs and donos not unmarshalling"

### DIFF
--- a/messageStructs.go
+++ b/messageStructs.go
@@ -145,11 +145,6 @@ type (
 		UUID      string `json:"uuid"`
 	}
 
-	eventUser struct {
-		User
-		CreatedDate string `json:"createdDate"`
-	}
-
 	// SubTier represents a dgg subscription tier
 	SubTier struct {
 		Tier  int64
@@ -168,16 +163,16 @@ type (
 	}
 
 	subscription struct {
-		Data      string    `json:"data"`
-		Timestamp int64     `json:"timestamp"`
-		Nick      string    `json:"nick"`
-		Tier      int64     `json:"tier"`
-		TierLabel string    `json:"tierLabel"`
-		Giftee    string    `json:"giftee"`
-		Quantity  int64     `json:"quantity"`
-		User      eventUser `json:"user"`
-		Recipient eventUser `json:"recipient"`
-		UUID      string    `json:"uuid"`
+		Data      string `json:"data"`
+		Timestamp int64  `json:"timestamp"`
+		Nick      string `json:"nick"`
+		Tier      int64  `json:"tier"`
+		TierLabel string `json:"tierLabel"`
+		Giftee    string `json:"giftee"`
+		Quantity  int64  `json:"quantity"`
+		User      User   `json:"user"`
+		Recipient User   `json:"recipient"`
+		UUID      string `json:"uuid"`
 	}
 
 	// Donation represents a dgg donation message
@@ -190,12 +185,12 @@ type (
 	}
 
 	donation struct {
-		Data      string    `json:"data"`
-		Timestamp int64     `json:"timestamp"`
-		Nick      string    `json:"nick"`
-		Amount    int64     `json:"amount"`
-		User      eventUser `json:"user"`
-		UUID      string    `json:"uuid"`
+		Data      string `json:"data"`
+		Timestamp int64  `json:"timestamp"`
+		Nick      string `json:"nick"`
+		Amount    int64  `json:"amount"`
+		User      User   `json:"user"`
+		UUID      string `json:"uuid"`
 	}
 
 	// Ping represents a pong response from the server

--- a/parsers.go
+++ b/parsers.go
@@ -195,34 +195,9 @@ func parseSubscription(s string) (Subscription, error) {
 		return Subscription{}, err
 	}
 
-	userTime, err := time.Parse("2006-01-02T15:04:05-0700", sub.User.CreatedDate)
-	if err != nil {
-		return Subscription{}, err
-	}
-
-	sender := User{
-		ID:          sub.User.ID,
-		Nick:        sub.User.Nick,
-		Features:    sub.User.Features,
-		CreatedDate: userTime,
-		Watching:    sub.User.Watching,
-	}
-
-	recipient := sender
-
-	if sub.Recipient.Nick != "" {
-		recipientTime, err := time.Parse("2006-01-02T15:04:05-0700", sub.Recipient.CreatedDate)
-		if err != nil {
-			return Subscription{}, err
-		}
-
-		recipient = User{
-			ID:          sub.Recipient.ID,
-			Nick:        sub.Recipient.Nick,
-			Features:    sub.Recipient.Features,
-			CreatedDate: recipientTime,
-			Watching:    sub.Recipient.Watching,
-		}
+	recipient := sub.Recipient
+	if recipient.Nick == "" {
+		recipient = sub.User
 	}
 
 	tier := SubTier{
@@ -231,7 +206,7 @@ func parseSubscription(s string) (Subscription, error) {
 	}
 
 	subscription := Subscription{
-		Sender:    sender,
+		Sender:    sub.User,
 		Recipient: recipient,
 		Timestamp: unixToTime(sub.Timestamp),
 		Message:   sub.Data,
@@ -249,21 +224,8 @@ func parseDonation(s string) (Donation, error) {
 		return Donation{}, err
 	}
 
-	userTime, err := time.Parse("2006-01-02T15:04:05-0700", dono.User.CreatedDate)
-	if err != nil {
-		return Donation{}, err
-	}
-
-	user := User{
-		ID:          dono.User.ID,
-		Nick:        dono.User.Nick,
-		Features:    dono.User.Features,
-		CreatedDate: userTime,
-		Watching:    dono.User.Watching,
-	}
-
 	donation := Donation{
-		Sender:    user,
+		Sender:    dono.User,
 		Timestamp: unixToTime(dono.Timestamp),
 		Message:   dono.Data,
 		Amount:    dono.Amount,


### PR DESCRIPTION
The bug with different timestamp format being sent by the website got fixed, so this workaround isn't necessary anymore.